### PR TITLE
NOREF - caching date with special format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ if (
     let result;
     if (clone == null) clone = true;
     if (typeof format === 'boolean') clone = format;
-    const key = getKey(date);
+    const key = getKey(date, format);
     if (key) {
       result = getFromCache(key, clone) || addToCache(key, date, format, clone);
     } else {
@@ -99,6 +99,8 @@ if (
   typeof exports === 'object' && typeof module !== 'undefined'
     ? (module.exports = momentCache)
     : typeof define === 'function' && define.amd
-      ? define(momentCache)
-      : scope != null ? (scope.momentCache = momentCache) : null;
+    ? define(momentCache)
+    : scope != null
+    ? (scope.momentCache = momentCache)
+    : null;
 })(initial, this);


### PR DESCRIPTION
Since most of our dates have special a format `DD.MM.YYYY` moment-cache was trying to parse an invalid date `for instance, 26.04.1998` https://github.com/deliveryhero/moment-cache/blob/master/lib/index.js#L40 and thus generating a new key in the storage named after `invalid date`. The problem is when it has more than one `invalid date` stored. 
This PR fixes that by passing onto `getKey` the desired format and ultimately a new correspondent key can be safely generated.

