### PR TITLE
[LOGWS-4319] Fix issue in logistics-moment-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,31 @@ During the app lifecycle we can call moment oftentimes. Every call is time. Time
 import moment from "moment";
 import cache from "moment-cache";
 
-const timeStamp = 628021800000;
 const momentCalls = 99999;
+const dateStringWithOffset = "2013-02-08 09+07:00";
+const timestamp = 628021800000;
+const dateString = "18-03-2024";
+const format = "DD-MM-YYYY";
 
-const check = (instance) => {
+const check = (instance, ...args) => {
   let i = 0;
   const start = new Date();
   while (i <= momentCalls) {
-    instance(timeStamp);
+    instance(...args);
     i++;
   }
   return new Date() - start;
 };
 
-console.log(check(moment)); // ~1035 ms
-console.log(check(cache)); // ~584 ms
+const cacheTimestamp = check(cache, timestamp); // ~33 ms
+const momentTimestamp = check(moment, timestamp); // ~41 ms
+
+const cacheDateString = check(cache, dateString, format); // ~60 ms
+const momentDateString = check(moment, dateString, format); // ~422 ms
+
+const cacheDateStringWithOffset = check(cache, dateStringWithOffset, format); // ~71 ms
+const momentDateStringWithOffset = check(moment, dateStringWithOffset, format); // ~408 ms
+
 ```
 
 ### Syntax:

--- a/README.md
+++ b/README.md
@@ -7,60 +7,57 @@ During the app lifecycle we can call moment oftentimes. Every call is time. Time
 ### Why?
 
 ```javascript
+import moment from "moment";
+import cache from "moment-cache";
 
-  import moment from 'moment';
-  import cache  from 'moment-cache';
+const timeStamp = 628021800000;
+const momentCalls = 99999;
 
-  const dateString = '2016-08-24';
-  const momentCalls = 99999;
-
-  const check = (instance) => {
-    let i = 0;
-    const start = new Date;
-    while (i <= momentCalls) {
-      instance(dateString);
-      i++;
-    }
-    return new Date - start;
+const check = (instance) => {
+  let i = 0;
+  const start = new Date();
+  while (i <= momentCalls) {
+    instance(timeStamp);
+    i++;
   }
+  return new Date() - start;
+};
 
-  console.log(check(moment));    // ~1588 ms
-  console.log(check(cache));     // ~35 ms
-
+console.log(check(moment)); // ~1035 ms
+console.log(check(cache)); // ~584 ms
 ```
 
-### Syntax: 
+### Syntax:
 
 #### Arguments:
- 
-* date: See [moment/parse](http://momentjs.com/docs/#/parsing/).
 
-* format: See [moment/format](http://momentjs.com/docs/#/parsing/string-format/).
+- date: See [moment/parse](http://momentjs.com/docs/#/parsing/).
+  <br/><b>If the date argument is a string in [date only form](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#:~:text=Date%2Donly%20form%3A%20YYYY%2C%20YYYY%2DMM%2C%20YYYY%2DMM%2DDD), it won't be cached since key value can be [wrong without offset](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#:~:text=When%20the%20time,Reality%20Issue)</b>.
 
-* clone (by default - **true**): set *false* if you are not going to change instance in future. Will increase performance, but any object changes will affect cached result. See [moment/clone](http://momentjs.com/docs/#/parsing/moment-clone/).
+- format: See [moment/format](http://momentjs.com/docs/#/parsing/string-format/).
+
+- clone (by default - **true**): set _false_ if you are not going to change instance in future. Will increase performance, but any object changes will affect cached result. See [moment/clone](http://momentjs.com/docs/#/parsing/moment-clone/).
 
 ```javascript
-
-  import cache from 'moment-cache'; // or moment().cache
-  const myDate = '06-28-2016';
-  const format = 'MM-DD-YYYY';
-  const date = cache(myDate, format); // moment.js cached instance
-  const anotherDate = cache(myDate, format); // rapidly retrieving previously processed result from the cache
-
+import cache from "moment-cache"; // or moment().cache
+const myDate = "06-28-2016";
+const format = "MM-DD-YYYY";
+const date = cache(myDate, format); // moment.js cached instance
+const anotherDate = cache(myDate, format); // rapidly retrieving previously processed result from the cache
 ```
-  
+
 #### Methods:
 
-**updateStorage**: change cache destination.  
- 
+**updateStorage**: change cache destination.
+
 ###### **Arguments**:
 
-* **storage**: object where cache data is stored. By default - covert object behind the scenes.
+- **storage**: object where cache data is stored. By default - covert object behind the scenes.
 
 ```javascript
-  import cachable from 'moment-cache';
-  const myStorage = {};
-  cachable.updateStorage(myStorage);
-  const date = cachable('2016-08-23');
-  console.log(myStorage); // {1471899600000: Moment}
+import cachable from "moment-cache";
+const myStorage = {};
+cachable.updateStorage(myStorage);
+const date = cachable("2016-08-23");
+console.log(myStorage); // {1471899600000: Moment}
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ import moment from "moment";
 import cache from "moment-cache";
 
 const momentCalls = 99999;
-const dateStringWithOffset = "2013-02-08 09+07:00";
+const invalidDateStringWithOffset = "2013-02-08 09+07:00";
+const dateStringWithOffset = "2020-05-12T23:50:21.817Z";
 const timestamp = 628021800000;
+const timeStampDate = "1989-11-25T18:30:00.000Z";
+
 const dateString = "18-03-2024";
 const format = "DD-MM-YYYY";
 
@@ -26,14 +29,26 @@ const check = (instance, ...args) => {
   return new Date() - start;
 };
 
-const cacheTimestamp = check(cache, timestamp); // ~33 ms
-const momentTimestamp = check(moment, timestamp); // ~41 ms
+const cacheTimestamp = check(cache, timestamp); // ~42 ms
+const momentTimestamp = check(moment, timestamp); // ~49 ms
 
-const cacheDateString = check(cache, dateString, format); // ~60 ms
-const momentDateString = check(moment, dateString, format); // ~422 ms
+const cacheDateString = check(cache, dateString, format); // ~65 ms
+const momentDateString = check(moment, dateString, format); // ~390 ms
 
-const cacheDateStringWithOffset = check(cache, dateStringWithOffset, format); // ~71 ms
-const momentDateStringWithOffset = check(moment, dateStringWithOffset, format); // ~408 ms
+const cacheDateStringWithOffset = check(cache, dateStringWithOffset); // ~218 ms
+const momentDateStringWithOffset = check(moment, dateStringWithOffset); // ~777 ms
+
+const cacheInvalidDateStringWithOffset = check(
+  cache,
+  invalidDateStringWithOffset
+); // ~75 ms
+const momentInvalidDateStringWithOffset = check(
+  moment,
+  invalidDateStringWithOffset
+); // ~571 ms
+
+const cacheTimestampDate = check(cache, timeStampDate); // ~202 ms
+const momentTimestampDate = check(moment, timeStampDate); // ~755 ms
 
 ```
 
@@ -68,6 +83,6 @@ const anotherDate = cache(myDate, format); // rapidly retrieving previously proc
 import cachable from "moment-cache";
 const myStorage = {};
 cachable.updateStorage(myStorage);
-const date = cachable("2016-08-23");
-console.log(myStorage); // {1471899600000: Moment}
+const date = cachable("23-08-2016", "DD-MM-YYYY");
+console.log(myStorage); // {23-08-2016 DD-MM-YYYY: MomentObject}
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,15 +37,19 @@ if (
   const getKey = (date, format) => {
     const dateType = typeof date;
     if (dateType === "string") {
-      const currentKey = new Date(date);
+      const regexp = new RegExp(
+        /^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/
+      );
+      if (regexp.test(date)) return null;
+
       if (format) {
         return `${date} ${format}`;
       } else {
+        const currentKey = new Date(date);
         return currentKey.toString();
       }
     } else if (dateType === "number") {
-      const currentDate = new Date(date);
-      return currentDate.toString();
+      return date;
     } else if (date instanceof Date) {
       return date.toString();
     } else {
@@ -69,18 +73,10 @@ if (
 
   const getCache = (date, format, clone) => {
     let result;
-    let useCache = true;
-    let regexp = new RegExp(
-      /^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/
-    );
-    let key = null;
 
     if (clone == null) clone = true;
     if (typeof format === "boolean") clone = format;
-    if (typeof date === "string") if (regexp.test(date)) useCache = false;
-    if (useCache) {
-      key = getKey(date, format);
-    }
+    const key = getKey(date, format);
     if (key) {
       result = getFromCache(key, clone) || addToCache(key, date, format, clone);
     } else {
@@ -108,8 +104,8 @@ if (
   typeof exports === "object" && typeof module !== "undefined"
     ? (module.exports = momentCache)
     : typeof define === "function" && define.amd
-      ? define(momentCache)
-      : scope != null
-        ? (scope.momentCache = momentCache)
-        : null;
+    ? define(momentCache)
+    : scope != null
+    ? (scope.momentCache = momentCache)
+    : null;
 })(initial, this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ if (
     if (dateType === "string") {
       const currentKey = new Date(date);
       if (format) {
-        return isNaN(currentKey) ? date : currentKey.toString();
+        return `${date} ${format}`;
       } else {
         return currentKey.toString();
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ if (
         return `${date} ${format}`;
       } else {
         const currentKey = new Date(date);
-        return currentKey.toString();
+        return isNaN(currentKey) ? date : currentKey.toString();
       }
     } else if (dateType === "number") {
       return date;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,20 @@
-const version = '0.1.3';
-let initial = typeof moment !== 'undefined' ? moment : null;
+const version = "0.1.3";
+let initial = typeof moment !== "undefined" ? moment : null;
 
 if (
-  typeof require !== 'undefined' &&
-  (typeof moment === 'undefined' || moment === null)
+  typeof require !== "undefined" &&
+  (typeof moment === "undefined" || moment === null)
 ) {
-  initial = require('moment-timezone') || initial;
+  initial = require("moment-timezone") || initial;
 }
 
-(function(moment, scope) {
-  'use strict';
+(function (moment, scope) {
+  "use strict";
 
   if (scope == null) {
-    if (typeof self != 'undefined') {
+    if (typeof self != "undefined") {
       scope = self;
-    } else if (typeof root != 'undefined') {
+    } else if (typeof root != "undefined") {
       scope = root;
     }
   }
@@ -27,7 +27,7 @@ if (
     return clone ? momentResult.clone() : momentResult;
   };
 
-  const initCache = opts => {
+  const initCache = (opts) => {
     if (opts.storage) {
       if (_prevCache == null) _prevCache = _cache;
       _cache = opts.storage;
@@ -36,14 +36,14 @@ if (
 
   const getKey = (date, format) => {
     const dateType = typeof date;
-    if (dateType === 'string') {
+    if (dateType === "string") {
       const currentKey = new Date(date);
       if (format) {
         return isNaN(currentKey) ? date : currentKey.toString();
       } else {
         return currentKey.toString();
       }
-    } else if (dateType === 'number') {
+    } else if (dateType === "number") {
       const currentDate = new Date(date);
       return currentDate.toString();
     } else if (date instanceof Date) {
@@ -69,9 +69,18 @@ if (
 
   const getCache = (date, format, clone) => {
     let result;
+    let useCache = true;
+    let regexp = new RegExp(
+      /^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/
+    );
+    let key = null;
+
     if (clone == null) clone = true;
-    if (typeof format === 'boolean') clone = format;
-    const key = getKey(date, format);
+    if (typeof format === "boolean") clone = format;
+    if (typeof date === "string") if (regexp.test(date)) useCache = false;
+    if (useCache) {
+      key = getKey(date, format);
+    }
     if (key) {
       result = getFromCache(key, clone) || addToCache(key, date, format, clone);
     } else {
@@ -84,7 +93,7 @@ if (
     if (moment.hasOwnProperty(key)) getCache[key] = moment[key];
   }
 
-  getCache.updateStorage = storage => {
+  getCache.updateStorage = (storage) => {
     if (storage == null && _prevCache) {
       storage = _prevCache;
     }
@@ -96,11 +105,11 @@ if (
 
   const momentCache = (moment.fn.cache = getCache);
 
-  typeof exports === 'object' && typeof module !== 'undefined'
+  typeof exports === "object" && typeof module !== "undefined"
     ? (module.exports = momentCache)
-    : typeof define === 'function' && define.amd
-    ? define(momentCache)
-    : scope != null
-    ? (scope.momentCache = momentCache)
-    : null;
+    : typeof define === "function" && define.amd
+      ? define(momentCache)
+      : scope != null
+        ? (scope.momentCache = momentCache)
+        : null;
 })(initial, this);

--- a/moment-cache.js
+++ b/moment-cache.js
@@ -1,21 +1,21 @@
-'use strict';
+"use strict";
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var version = '0.1.3';
-var initial = typeof moment !== 'undefined' ? moment : null;
+var version = "0.1.3";
+var initial = typeof moment !== "undefined" ? moment : null;
 
-if (typeof require !== 'undefined' && (typeof moment === 'undefined' || moment === null)) {
-  initial = require('moment-timezone') || initial;
+if (typeof require !== "undefined" && (typeof moment === "undefined" || moment === null)) {
+  initial = require("moment-timezone") || initial;
 }
 
 (function (moment, scope) {
-  'use strict';
+  "use strict";
 
   if (scope == null) {
-    if (typeof self != 'undefined') {
+    if (typeof self != "undefined") {
       scope = self;
-    } else if (typeof root != 'undefined') {
+    } else if (typeof root != "undefined") {
       scope = root;
     }
   }
@@ -36,15 +36,15 @@ if (typeof require !== 'undefined' && (typeof moment === 'undefined' || moment =
   };
 
   var getKey = function getKey(date, format) {
-    var dateType = typeof date === 'undefined' ? 'undefined' : _typeof(date);
-    if (dateType === 'string') {
+    var dateType = typeof date === "undefined" ? "undefined" : _typeof(date);
+    if (dateType === "string") {
       var currentKey = new Date(date);
       if (format) {
         return isNaN(currentKey) ? date : currentKey.toString();
       } else {
         return currentKey.toString();
       }
-    } else if (dateType === 'number') {
+    } else if (dateType === "number") {
       var currentDate = new Date(date);
       return currentDate.toString();
     } else if (date instanceof Date) {
@@ -70,9 +70,16 @@ if (typeof require !== 'undefined' && (typeof moment === 'undefined' || moment =
 
   var getCache = function getCache(date, format, clone) {
     var result = void 0;
+    var useCache = true;
+    var regexp = new RegExp(/^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/);
+    var key = null;
+
     if (clone == null) clone = true;
-    if (typeof format === 'boolean') clone = format;
-    var key = getKey(date, format);
+    if (typeof format === "boolean") clone = format;
+    if (typeof date === "string") if (regexp.test(date)) useCache = false;
+    if (useCache) {
+      key = getKey(date, format);
+    }
     if (key) {
       result = getFromCache(key, clone) || addToCache(key, date, format, clone);
     } else {
@@ -97,5 +104,5 @@ if (typeof require !== 'undefined' && (typeof moment === 'undefined' || moment =
 
   var momentCache = moment.fn.cache = getCache;
 
-  (typeof exports === 'undefined' ? 'undefined' : _typeof(exports)) === 'object' && typeof module !== 'undefined' ? module.exports = momentCache : typeof define === 'function' && define.amd ? define(momentCache) : scope != null ? scope.momentCache = momentCache : null;
+  (typeof exports === "undefined" ? "undefined" : _typeof(exports)) === "object" && typeof module !== "undefined" ? module.exports = momentCache : typeof define === "function" && define.amd ? define(momentCache) : scope != null ? scope.momentCache = momentCache : null;
 })(initial, undefined);

--- a/moment-cache.js
+++ b/moment-cache.js
@@ -38,15 +38,17 @@ if (typeof require !== "undefined" && (typeof moment === "undefined" || moment =
   var getKey = function getKey(date, format) {
     var dateType = typeof date === "undefined" ? "undefined" : _typeof(date);
     if (dateType === "string") {
-      var currentKey = new Date(date);
+      var regexp = new RegExp(/^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/);
+      if (regexp.test(date)) return null;
+
       if (format) {
         return date + " " + format;
       } else {
+        var currentKey = new Date(date);
         return currentKey.toString();
       }
     } else if (dateType === "number") {
-      var currentDate = new Date(date);
-      return currentDate.toString();
+      return date;
     } else if (date instanceof Date) {
       return date.toString();
     } else {
@@ -70,16 +72,10 @@ if (typeof require !== "undefined" && (typeof moment === "undefined" || moment =
 
   var getCache = function getCache(date, format, clone) {
     var result = void 0;
-    var useCache = true;
-    var regexp = new RegExp(/^(?:\d{4})(?:-(0?[1-9]|1[0-2]))?$|^(?:\d{4})(?:-(0?[1-9]|1[0-2]))(?:-(0?[1-9]|1[0-9]|2[0-9]|3[01]))?$/);
-    var key = null;
 
     if (clone == null) clone = true;
     if (typeof format === "boolean") clone = format;
-    if (typeof date === "string") if (regexp.test(date)) useCache = false;
-    if (useCache) {
-      key = getKey(date, format);
-    }
+    var key = getKey(date, format);
     if (key) {
       result = getFromCache(key, clone) || addToCache(key, date, format, clone);
     } else {

--- a/moment-cache.js
+++ b/moment-cache.js
@@ -45,7 +45,7 @@ if (typeof require !== "undefined" && (typeof moment === "undefined" || moment =
         return date + " " + format;
       } else {
         var currentKey = new Date(date);
-        return currentKey.toString();
+        return isNaN(currentKey) ? date : currentKey.toString();
       }
     } else if (dateType === "number") {
       return date;

--- a/moment-cache.js
+++ b/moment-cache.js
@@ -40,7 +40,7 @@ if (typeof require !== "undefined" && (typeof moment === "undefined" || moment =
     if (dateType === "string") {
       var currentKey = new Date(date);
       if (format) {
-        return isNaN(currentKey) ? date : currentKey.toString();
+        return date + " " + format;
       } else {
         return currentKey.toString();
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@deliveryhero/logistics-moment-cache",
       "version": "0.1.15",
       "dependencies": {
-        "moment": "2.29.4",
-        "moment-timezone": "0.5.40"
+        "moment": "2.30.1",
+        "moment-timezone": "0.5.44"
       },
       "devDependencies": {
         "babel-cli": "^6.9.0",
@@ -2770,19 +2770,19 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.40",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
-      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
+      "version": "0.5.44",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.44.tgz",
+      "integrity": "sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -7103,16 +7103,16 @@
       }
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "moment-timezone": {
-      "version": "0.5.40",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
-      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
+      "version": "0.5.44",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.44.tgz",
+      "integrity": "sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "ms": {


### PR DESCRIPTION
Some issues were noted in moment-cache repository that can result in wrong date time parsing. They are listed below.
Most issues arise because we use Date object to create the storage keys.
### Issue 1
moment.js library can handle many formats. Unfortunately we do not consider them when creating the keys in moment-cache.

```
const myDate = '03-06-2016';
const format = 'DD-MM-YYYY';
const myAnotherDate = "03-06-2016";
const anotherFormat = "MM-DD-YYYY";
const date = moment(myDate, format); // moment.js cached instance
const anotherDate = moment(myAnotherDate, anotherFormat);

```
Both would output same result in moment-cache.

**Solution**
We can store the date with format. If we parse them using the format and then create a key, it will just make cache slower.

### Issue 2
[Date only forms are parsed as utc in Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#:~:text=When%20the%20time,Reality%20Issue.). Moment parses this in local time.
Date only forms include YYYY, YYYY-MM, YYYY-MM-DD


```
const dateString = "2024-03-18";
const incorrectDate = "2024-03-18T01:00:00+01:00";
const initialDate = moment(dateString);
const cacheDate = moment(incorrectDate).format();
const momentDate = momentOriginal(incorrectDate).format();
console.log("cacheDate", cacheDate)
console.log("momentDate", momentDate)

// In berlin timezone this would output -
cacheDate 2024-03-18T00:00:00+01:00
momentDate 2024-03-18T01:00:00+01:00
```

**Solution**
We can avoid caching date only forms.

### Issue 3
Moment-cache is slow when parsing timestamps.

```
const timeStamp = 628021800000;
const momentCalls = 99999;

const check = (instance) => {
  let i = 0;
  const start = new Date();
  while (i <= momentCalls) {
    instance(timeStamp);
    i++;
  }
  return new Date() - start;
};

// current speed 
console.log("cache", check(cache)); // ~147 ms
console.log("moment", check(moment)); // ~56 ms
```

**Solution**
If instead of parsing and storing the date string, we store the timestamp value as key, the speed increases.

```
// new speed 
console.log("cache", check(cache)); // ~41 ms
console.log("moment", check(moment)); // ~49 ms
```

These modifications can be checked live here - https://codesandbox.io/p/sandbox/gracious-sara-wv6p28
